### PR TITLE
Support url context path with hostUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Run tests with grunt.
 ```javascript
 var generalOptions = {
   appHandler: app, // an Express application
-  hostUrl: 'http://domain.here.com:port', // required for return URLs
+  hostUrl: 'http://domain.here.com:port[/path]', // required for return URLs, and binding to optional /path
 };
 
 var tupas = require('tupas').create(generalOptions);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tupas",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "A module for TUPAS identification.",
   "main": "tupas.js",
   "homepage" : "https://github.com/reaktor/node-tupas",


### PR DESCRIPTION
globalOpts now supports this form of hostUrl: 'https://localhost:' + config.port + '/myContext'
POST and GET return urls have been tested and work with '/myContext'